### PR TITLE
Skip monitoring of test if flag is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,18 +11,27 @@ The step will fail if any test is not passing.
 
 You must provide the following values:
 
-* `runscope_access_token`: This step will make calls to the Runscope API and
+* `runscope-access-token`: This step will make calls to the Runscope API and
 requires an authorization token to do so. Read the [Runscope documentation](https://www.runscope.com/docs/api/authentication)
 for further information.
-* `runscope_trigger_token`: This token/id will be used to start a test in a
-bucket. To obtain this token, please proceed to the [Runscope documentation](https://www.runscope.com/docs/api-testing/integrations).
+
+ _Note_: This variable is required when `skip-monitoring` is set to `false`
+
+* `runscope-trigger-token`: This token/id will be used to start a test in a
+bucket. 
+
+ To obtain this token, please proceed to the [Runscope documentation](https://www.runscope.com/docs/api-testing/integrations).
 
 ## Optional variables
 
 The following variable is optional:
 
-* `runscope_environment_uuid`: The environment in which the tests will be executed.
+* `runscope-environment-uuid`: The environment in which the tests will be executed.
 This will fall back to the default environment defined in your bucket if it is omitted.
+* `skip-monitoring` (Default: `false`): When this flag is enabled, the script will
+not attempt to do any further calls to Runscope to monitor the execution of the tests.
+Thus the `runscope-access-token` is only required, when this variable is set to
+`true`.
 
 ## Example
 
@@ -33,4 +42,5 @@ deploy:
           access-token: $RUNSCOPE_ACCESS_TOKEN
           trigger-token: $RUNSCOPE_TRIGGER_TOKEN
           environment-uuid: $RUNSCOPE_ENVIRONMENT_UUID
+          skip-monitoring: "false"
 ```

--- a/run.sh
+++ b/run.sh
@@ -42,7 +42,9 @@ main() {
     fail "Failed to start Runscope bucket tests."
   else
     if [ "$WERCKER_RUNSCOPE_BUCKET_TRIGGER_SKIP_MONITORING" = "true" ]; then
-      info "Skip waiting for test to complete. Please go directly to Runscope to see the results."
+      TEST_RUN_URL=$(extract_json_value ".data.runs | .[0] | .test_run_url" "$WERCKER_STEP_TEMP/result.json")
+      info "Skip waiting for test to complete."
+      info "Please go directly to Runscope to see the results: $TEST_RUN_URL"
     else
       BUCKET_KEY=$(extract_json_value ".data.runs | .[0] | .bucket_key" "$WERCKER_STEP_TEMP/result.json")
       TEST_ID=$(extract_json_value ".data.runs | .[0] | .test_id" "$WERCKER_STEP_TEMP/result.json")

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,5 +1,5 @@
 name: runscope-bucket-trigger
-version: 1.0.1
+version: 1.0.10
 description: Triggers all tests in a Runscope bucket and waits for a successful response.
 keywords:
   - runscope
@@ -7,10 +7,14 @@ keywords:
 properties:
   access_token:
     type: string
-    required: true
-  trigger_token:
-    type: string
-    required: true
+    required: false
   environment_uuid:
     type: string
     required: false
+  skip_monitoring:
+    type: string
+    required: false
+    default: "false"
+  trigger_token:
+    type: string
+    required: true


### PR DESCRIPTION
This PR adds the feature to skip the monitoring done by this step entirely.

If any test in the defined Runscope bucket fails, there will be no notification in Wercker itself.
The required information can still be obtained by going directly to Runscope.

The aim of this feature is to trim down the time required for a deployment in wercker.