### PR TITLE
Skip the whole step if required

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ This will fall back to the default environment defined in your bucket if it is o
 not attempt to do any further calls to Runscope to monitor the execution of the tests.
 Thus the `runscope-access-token` is only required, when this variable is set to
 `true`.
+* `skip` (Default: `false`): Skip this test entirely. This variable
+should be set if you want to skip the exection in one pipeline.
 
 ## Example
 
@@ -43,4 +45,5 @@ deploy:
           trigger-token: $RUNSCOPE_TRIGGER_TOKEN
           environment-uuid: $RUNSCOPE_ENVIRONMENT_UUID
           skip-monitoring: $RUNSCOPE_SKIP_MONITORING
+          skip: $RUNSCOPE_SKIP_TRIGGER
 ```

--- a/run.sh
+++ b/run.sh
@@ -10,6 +10,11 @@ extract_json_value() {
 }
 
 main() {
+  # skip the script on demand...
+  if [ "$WERCKER_RUNSCOPE_BUCKET_TRIGGER_SKIP_TRIGGER" = "true" ]; then
+    info "Skipping this step entirely."
+    exit 0
+  fi
 
   # check if required tools are installed
   command -v curl >/dev/null 2>&1 || fail "Please install curl to execute this step."

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,5 +1,5 @@
 name: runscope-bucket-trigger
-version: 1.0.11
+version: 1.1.0
 description: Triggers all tests in a Runscope bucket and waits for a successful response.
 keywords:
   - runscope
@@ -18,3 +18,7 @@ properties:
   trigger-token:
     type: string
     required: true
+  skip-trigger:
+    type: string
+    required: false
+    default: "false"


### PR DESCRIPTION
This PR adds the option to skip the whole trigger per pipeline.
Skipping is disabled by default, so you may want to enable skipping for your `sandbox` or `development` environments.